### PR TITLE
use open instead of opn; close process after opening URLs

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 #! /usr/bin/env node
 
 const chalk = require('chalk');
-const opn = require('opn');
+const open = require('open');
 const shared = require('./bin/shared.js');
 const help = require('./bin/help.js');
 const tasks = require('./bin/vscode_tasks.js');
@@ -25,11 +25,11 @@ if (safeList.indexOf(command_name) < 0 && !shared.pico_exe_path) {
 
 switch (command_name) {
 	case "bbs":
-		opn('https://www.lexaloffle.com/bbs');
+		open('https://www.lexaloffle.com/bbs').then(proc => proc.unref());
 		break;
 
 	case "home":
-		opn('https://www.github.com/nicholaswagner/pico-tools');
+		open('https://www.github.com/nicholaswagner/pico-tools').then(proc => proc.unref());
 		break;
 
 	case "build":

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "config": "^1.30.0",
     "dotenv": "^5.0.1",
     "find-process": "^1.1.1",
-    "opn": "^5.3.0",
+    "open": "^7.0.0",
     "prompt": "^1.0.0"
   },
   "devDependencies": {},


### PR DESCRIPTION
I realize this project may be abandoned, but in case it isn't...

[opn](https://npm.im/opn) is now [open](https://npm.im/open), so upgrade.
On macOS anyway, calling `open()` will wait for the spawned process to quit before closing the main process,
which is annoying.  This PR changes that behavior so the main process exits after spawning.